### PR TITLE
Add instruction for working with program build artifacts

### DIFF
--- a/ExtSort.Tests/KMergeOrderTests.cs
+++ b/ExtSort.Tests/KMergeOrderTests.cs
@@ -1,13 +1,14 @@
 ﻿using ExtSort.Code.Comparers;
 using ExtSort.Code.Extensions;
 using ExtSort.Models.Sorter;
+using System.Numerics;
 
 namespace ExtSort.Tests
 {
     [TestClass]
     public class KMergeOrderTests
     {
-        private MultiColumnComparer<(string Str, int Int)> _comparer;
+        private MultiColumnComparer<(string Str, BigInteger Int)> _comparer;
         private Queue<string> _1stList;
         private Queue<string> _2ndList;
         private Queue<string> _3rdList;
@@ -16,12 +17,12 @@ namespace ExtSort.Tests
         [TestInitialize]
         public void Setup()
         {
-            var comparisons = new Comparison<(string Str, int Int)>[]
+            var comparisons = new Comparison<(string Str, BigInteger Int)>[]
             {
                 (x, y) => x.Str.AsSpan().CompareTo(y.Str.AsSpan(), StringComparison.Ordinal),
                 (x, y) => x.Int.CompareTo(y.Int)
             };
-            _comparer = new MultiColumnComparer<(string Str, int Int)>(comparisons);
+            _comparer = new MultiColumnComparer<(string Str, BigInteger Int)>(comparisons);
             _1stList = new Queue<string>(Get1stOrderedList());
             _2ndList = new Queue<string>(Get2ndOrderedList());
             _3rdList = new Queue<string>(Get3rdOrderedList());
@@ -32,7 +33,7 @@ namespace ExtSort.Tests
         public void VerifyCorrectOrderWithTaskTestComparatorMerge()
         {
             var array = new Queue<string>[] { _1stList, _2ndList, _3rdList };
-            var queue = new PriorityQueue<Entry, (string, int)>(array.Length, _comparer);
+            var queue = new PriorityQueue<Entry, (string, BigInteger)>(array.Length, _comparer);
             for (var i = 0; i < array.Length; ++i)
             {
                 var value = array[i].Dequeue();

--- a/ExtSort.Tests/SortOrderTests.cs
+++ b/ExtSort.Tests/SortOrderTests.cs
@@ -1,6 +1,6 @@
 using ExtSort.Code.Comparers;
 using ExtSort.Code.Extensions;
-
+using System.Numerics;
 using System.Text;
 
 namespace ExtSort.Tests
@@ -8,19 +8,19 @@ namespace ExtSort.Tests
     [TestClass]
     public class SortOrderTests
     {
-        private MultiColumnComparer<(string Str, int Int)> _comparer;
+        private MultiColumnComparer<(string Str, BigInteger Int)> _comparer;
         private string[] _data;
         private string[] _correctData;
 
         [TestInitialize]
         public void Setup()
         {
-            var comparisons = new Comparison<(string Str, int Int)>[]
+            var comparisons = new Comparison<(string Str, BigInteger Int)>[]
             {
                 (x, y) => x.Str.AsSpan().CompareTo(y.Str.AsSpan(), StringComparison.Ordinal),
                 (x, y) => x.Int.CompareTo(y.Int)
             };
-            _comparer = new MultiColumnComparer<(string Str, int Int)>(comparisons);
+            _comparer = new MultiColumnComparer<(string Str, BigInteger Int)>(comparisons);
             _data =
             [
                 "415. Apple",
@@ -42,7 +42,7 @@ namespace ExtSort.Tests
         [TestMethod]
         public void VerifyCorrectOrderWithTaskTestComparatorSort()
         {
-            var buffer = new (string Str, int Int)[_data.Length];
+            var buffer = new (string Str, BigInteger Int)[_data.Length];
             for(var i = 0; i < _data.Length; ++i)
             {
                 if (_data[i].TryParsePriority(out var priority))

--- a/ExtSort.sln
+++ b/ExtSort.sln
@@ -7,6 +7,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtSort", "ExtSort\ExtSort.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtSort.Tests", "ExtSort.Tests\ExtSort.Tests.csproj", "{4CFCC967-1388-4835-AD33-67ED8E252875}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8C8EE5EC-AAA5-42D0-820E-A7B9420463C3}"
+	ProjectSection(SolutionItems) = preProject
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		LICENSE.txt = LICENSE.txt
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/ExtSort/Code/Extensions/StringExtensions.cs
+++ b/ExtSort/Code/Extensions/StringExtensions.cs
@@ -21,5 +21,15 @@
 
             return false;
         }
+
+        public static string Eclipse(this string input, int maxLength)
+        {
+            if (string.IsNullOrEmpty(input)) return input;
+            if (input.Length <= maxLength) return input;
+            const string eclipse = "...";
+            var firstPart = input.AsSpan(0, maxLength / 2);
+            var lastPart = input.AsSpan(input.Length - maxLength / 2);
+            return string.Concat(firstPart, eclipse, lastPart);
+        }
     }
 }

--- a/ExtSort/Code/Extensions/StringExtensions.cs
+++ b/ExtSort/Code/Extensions/StringExtensions.cs
@@ -1,8 +1,10 @@
-﻿namespace ExtSort.Code.Extensions
+﻿using System.Numerics;
+
+namespace ExtSort.Code.Extensions
 {
     internal static class StringExtensions
     {
-        public static bool TryParsePriority(this string input, out (string Str, int Int) result)
+        public static bool TryParsePriority(this string input, out (string Str, BigInteger Int) result)
         {
             result = default;
             if (string.IsNullOrEmpty(input))
@@ -13,7 +15,7 @@
             if (idx == -1)
                 return false;
 
-            if (int.TryParse(span.Slice(0, idx), out result.Int))
+            if (BigInteger.TryParse(span.Slice(0, idx), out result.Int))
             {
                 result.Str = span.Slice(idx + 1).ToString();
                 return true;

--- a/ExtSort/Models/Settings/ReadWritePath.cs
+++ b/ExtSort/Models/Settings/ReadWritePath.cs
@@ -5,7 +5,7 @@ namespace ExtSort.Models.Settings
 {
     public class ReadWritePath
     {
-        public string SplitReadPath { get; init; } = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+        public string SplitReadPath { get; init; } = Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory);
         public string SortReadPath { get; init; }
         public string SortWritePath { get; init; }
         public string MergeStartPath { get; init; }

--- a/ExtSort/Models/Settings/ReadWritePath.cs
+++ b/ExtSort/Models/Settings/ReadWritePath.cs
@@ -25,6 +25,11 @@ namespace ExtSort.Models.Settings
             if (string.IsNullOrEmpty(MergeStartTargetPath))
                 errors.AppendLine("The target path to merge files is not specified.");
 
+            Directory.CreateDirectory(SortReadPath);
+            Directory.CreateDirectory(SortWritePath);
+            Directory.CreateDirectory(MergeStartPath);
+            Directory.CreateDirectory(MergeStartTargetPath);
+
             return errors.Length == 0;
         }
     }

--- a/ExtSort/Program.cs
+++ b/ExtSort/Program.cs
@@ -9,7 +9,7 @@ using ExtSort.Code.Extensions;
 using ExtSort.Services.Factories;
 
 var config = new ConfigurationBuilder();
-var path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+var path = Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory);
 config.SetBasePath(path).AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 
 var rootCommand = new RootCommand("External merge sorting with an input generator");

--- a/ExtSort/Services/Sorter/Implementation/SorterCPUService.cs
+++ b/ExtSort/Services/Sorter/Implementation/SorterCPUService.cs
@@ -2,6 +2,7 @@
 using ExtSort.Models.Settings;
 using ExtSort.Services.Sorter.Implementation;
 using System.Diagnostics;
+using System.Numerics;
 using System.Text;
 
 namespace ExtSort.Services.Sorter
@@ -133,7 +134,7 @@ namespace ExtSort.Services.Sorter
                             {
                                 using (var writer = new StreamWriter(stream, bufferSize: _settings.SortOutputBufferSize))
                                 {
-                                    var builder = new StringBuilder(); (string Str, int Int) row;
+                                    var builder = new StringBuilder(); (string Str, BigInteger Int) row;
                                     while (queue.TryDequeue(out _, out row) && !token.IsCancellationRequested)
                                     {
                                         writer.WriteLine(builder.Append(row.Int).Append('.').Append(row.Str));

--- a/ExtSort/Services/Sorter/Implementation/SorterCPUService.cs
+++ b/ExtSort/Services/Sorter/Implementation/SorterCPUService.cs
@@ -42,8 +42,10 @@ namespace ExtSort.Services.Sorter
             await SplitFile(srcFile, _settings.NumberOfFiles, token);
 
             Console.WriteLine($"{Environment.NewLine}--Merging--");
-            var sortedFiles = _io.MoveTmpFilesToSorted(_settings.IOPath.MergeStartTargetPath);
-            await _io.MergeFiles(sortedFiles, dstFile, token);
+            var sortedFiles = _io.MoveTmpFilesToSorted(_settings.IOPath.SortWritePath);
+            var source = _settings.IOPath.SortWritePath;
+            var target = _settings.IOPath.MergeStartTargetPath;
+            await _io.MergeFiles(sortedFiles, dstFile, source, target, token);
         }
 
         private async Task SplitFile(string srcFile, long numberOfFiles, CancellationToken token)

--- a/ExtSort/Services/Sorter/Implementation/SorterIOService.cs
+++ b/ExtSort/Services/Sorter/Implementation/SorterIOService.cs
@@ -140,11 +140,11 @@ namespace ExtSort.Services.Sorter.Implementation
             var start = 0;
             do
             {
-                var iterator = unsortedFiles.Skip(start).Take(pageStep);
+                var iterator = unsortedFiles.Skip(start).Take(pageStep).ToArray();
                 if (iterator.Any())
                 {
                     Console.WriteLine($"Page: {page + 1}");
-                    var digits = iterator.Select(file => Path.GetFileNameWithoutExtension(file));
+                    var digits = iterator.Select(file => Path.GetFileNameWithoutExtension(file)).ToArray();
                     Console.WriteLine($"Sorting: [{string.Join(", ", digits)}]{_UnsortedFileExtension}");
                     foreach (var file in iterator)
                     {
@@ -160,7 +160,7 @@ namespace ExtSort.Services.Sorter.Implementation
                     }
                     await Task.WhenAll(sortedTasks);
 
-                    var sortedPage = sorted.ToList().Chunk(chunkSize).Skip(0).Take(pageStepMerge);
+                    var sortedPage = sorted.ToList().Chunk(chunkSize).Skip(0).Take(pageStepMerge).ToArray();
                     var mergeTask = KWayMerge(sortedPage, mergeTargetLocation, mergeSourceLocation, token);
                     mergeTasks.Add(mergeTask);
 
@@ -246,7 +246,7 @@ namespace ExtSort.Services.Sorter.Implementation
                 _mergeTempCounter = 0;
                 do
                 {
-                    var sortedPage = sortedFiles.Chunk(chunkSize).Skip(step).Take(pageStep);
+                    var sortedPage = sortedFiles.Chunk(chunkSize).Skip(step).Take(pageStep).ToArray();
                     if (!sortedPage.Any()) break;
                     Console.WriteLine($"Page: {page + 1}");
                     await KWayMerge(sortedPage, mergeTargetLocation, mergeSourceLocation, token);
@@ -277,7 +277,7 @@ namespace ExtSort.Services.Sorter.Implementation
                 var counter = Interlocked.Increment(ref _mergeTempCounter);
                 var outputFilename = $"{counter}{_SortedFileExtension}{_TempFileExtension}";
                 var targetPath = Path.Combine(mergeTargetLocation, outputFilename);
-                var digits = chunk.Select(file => Path.GetFileNameWithoutExtension(file));
+                var digits = chunk.Select(file => Path.GetFileNameWithoutExtension(file)).ToArray();
                 Console.WriteLine($"Merging [{string.Join(", ", digits)}]{_SortedFileExtension} into: {outputFilename}");
 
                 if (chunk.Length > 1)

--- a/ExtSort/Services/Sorter/Implementation/SorterIOService.cs
+++ b/ExtSort/Services/Sorter/Implementation/SorterIOService.cs
@@ -4,6 +4,7 @@ using ExtSort.Models.Settings;
 using ExtSort.Models.Sorter;
 
 using System.Collections.Concurrent;
+using System.Numerics;
 using System.Text;
 
 namespace ExtSort.Services.Sorter.Implementation
@@ -174,7 +175,7 @@ namespace ExtSort.Services.Sorter.Implementation
         private void SortFile(string unsortedFilePath, string sortedFilePath, int numberOfLines, CancellationToken token)
         {
             long targetSize = 0;
-            var buffer = new (string Str, int Int)[numberOfLines];
+            var buffer = new (string Str, BigInteger Int)[numberOfLines];
             using (var unsorted = File.OpenRead(unsortedFilePath))
             {
                 using var buffered = new BufferedStream(unsorted);
@@ -208,7 +209,7 @@ namespace ExtSort.Services.Sorter.Implementation
                 {
                     var builder = new StringBuilder();
                     var index = 0;
-                    (string Str, int Int) row;
+                    (string Str, BigInteger Int) row;
                     while (index < buffer.Length && !token.IsCancellationRequested)
                     {
                         row = buffer[index];
@@ -344,7 +345,7 @@ namespace ExtSort.Services.Sorter.Implementation
         private StreamReader[] InitKWayMergeFromStreams(
             IReadOnlyList<string> sortedFiles,
             string readerSourcePath,
-            out PriorityQueue<Entry, (string, int)> queue)
+            out PriorityQueue<Entry, (string, BigInteger)> queue)
         {
             var streamReaders = new StreamReader[sortedFiles.Count];
             queue = BuildQueue<Entry>(sortedFiles.Count); 
@@ -387,15 +388,15 @@ namespace ExtSort.Services.Sorter.Implementation
             return sortedFiles;
         }
 
-        internal PriorityQueue<T, (string, int)> BuildQueue<T>(int capacity)
+        internal PriorityQueue<T, (string, BigInteger)> BuildQueue<T>(int capacity)
         {
-            var comparisons = new Comparison<(string Str, int Int)>[]
+            var comparisons = new Comparison<(string Str, BigInteger Int)>[]
             {
                 (x, y) => x.Str.AsSpan().CompareTo(y.Str.AsSpan(), StringComparison.Ordinal),
                 (x, y) => x.Int.CompareTo(y.Int)
             };
-            var comparer = new MultiColumnComparer<(string Str, int Int)>(comparisons);
-            return new PriorityQueue<T, (string, int)>(capacity, comparer);
+            var comparer = new MultiColumnComparer<(string Str, BigInteger Int)>(comparisons);
+            return new PriorityQueue<T, (string, BigInteger)>(capacity, comparer);
         }
 
         public void Dispose()

--- a/ExtSort/Services/Sorter/Implementation/SorterIOService.cs
+++ b/ExtSort/Services/Sorter/Implementation/SorterIOService.cs
@@ -259,8 +259,7 @@ namespace ExtSort.Services.Sorter.Implementation
 
             token.ThrowIfCancellationRequested();
             var resultPath = Path.Combine(mergeSourceLocation, sortedFiles[0]);
-            var outputPath = Path.Combine(mergeSourceLocation, targetName);
-            File.Move(resultPath, outputPath, true);
+            File.Move(resultPath, targetName, true);
         }
 
         private async Task KWayMerge(IEnumerable<string[]> sortedChunks,

--- a/README.md
+++ b/README.md
@@ -152,3 +152,27 @@ The general merging strategy: ```4096 -> 512``` (during the Sorting/Merging Phas
 [Visual Studio Unit Tests](https://www.nuget.org/packages/Microsoft.NET.Test.SDK)
 
 [Microsoft.Extensions.Configuration](https://www.nuget.org/packages/microsoft.extensions.configuration/)
+
+## How to run the program
+
+The result of executing the `dotnet build` command is a whole bunch of files that are tedious to
+administer. Therefore, it is convenient to work with a compact view of the program, which can be
+obtained by executing the `dotnet publish` command.
+
+1. In project folder `ExtSort` execute command:
+
+```powershell
+dotnet publish -c Release -r win-x64 --self-contained true -p:PublishReadyToRun=false,PublishTrimmed=true,PublishSingleFile=true
+```
+
+2. Find needed files in subfolder:
+
+`ExtSort\bin\Release\net6.0\win-x64\publish\`  
+3. Run with the command as in the example:
+
+```powershell
+$Time = [System.Diagnostics.Stopwatch]::StartNew()
+& ".\ExtSort.exe" "sort" "input.txt" "output.txt" "IO"
+write-host ('Completed in {0} seconds.' -f $Time.Elapsed.TotalSeconds)
+$Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+```


### PR DESCRIPTION
**What was done**

[Adds instruction for working with program build artifacts](https://github.com/dudinda/External-Merge-Sorting/commit/b6d690a41699a82ab6782e9816fccf232c0cb2ca)
The `dotnet build` command generates a whole bunch of files at the output, and it's a pain to figure them out. That's why I added instructions to the `readme` file on how to get a compact representation of the executable file using the `dotnet publish` command.


[Fix value cannot be null exception](https://github.com/dudinda/External-Merge-Sorting/commit/70d1d93ea90d6ba50375a5dc5e00639577b241c7)
In the executable file obtained with the `PublishSingleFile` option, expression `Assembly.GetEntryAssembly().Location` always returns `null`. This resulted in the program crashing with exception `Value cannot be null`. Therefore, I replaced expression `Assembly.GetEntryAssembly().Location` with expression `AppDomain.CurrentDomain.BaseDirectory`.


[Fix could not find a part of the path exception](https://github.com/dudinda/External-Merge-Sorting/commit/77f2090f07f0eb616f5aecc8a19077e85895301b)
If the user-configured folders for temporary files were missing, the program crashing with exception `Could not find a part of the path`. I believe that a program should not crash with an error when it can solve the problem itself, and should not force the user to do extra work when he has already specified the desired folder. So I added a call to `Directory.CreateDirectory` for temporary file folders.


[Fix the path of the generated sort output file](https://github.com/dudinda/External-Merge-Sorting/commit/abbefad4e9f28002e6115e1826193bc3b450100d)
The sorting program tries to put the result file into a temporary folder. I think that the user needs the result exactly along the path he specified. Corrected the file generation path.


[Fix sorting of small files in cpu mode](https://github.com/dudinda/External-Merge-Sorting/commit/23e9e8a0d395e00bde7c261de773608c5f07308c)
When sorting small files in CPU mode, the program outputs only the first line to the resulting file. This happens because `StreamReader` reads files from the underlying `Stream` page by page, and the page size may be larger than the original file. So the size of the read file is immediately larger than the calculated size of the intermediate file. I fixed sorting in CPU mode for small files.


[Fix log messaging frequency in cpu mode](https://github.com/dudinda/External-Merge-Sorting/commit/955d4c4cea9ba6f841ae11b9bf534880ba6bd529)
Debug messages are printed to the console without delay too often to be read. That's why I added selective output of messages after a certain time via `Stopwatch`.

[Fix there is not enough space on the disk exception](https://github.com/dudinda/External-Merge-Sorting/commit/fd8555b8dd7f1082be3baeb780d5c240c9106764)
Continuing to run after a format string error resulted in the generation of an intermediate file from the short (sometimes even empty) queue. Which, in accordance with the preset intermediate file size disabled in fix [23e9e8a](https://github.com/dudinda/External-Merge-Sorting/commit/23e9e8a0d395e00bde7c261de773608c5f07308c#diff-76aa62fd9e2e5e59e6491095ef65d6425c79c2b016f0c438824e18f844d3ab84L85), resulted in the generation of many heavy files crashing with exception `There is not enough space on the disk`. Fixed it so that now execution stops when there is a string format error. Also added generation of the corresponding exception. And the necessary method for beautifully shortening the error message.


[Fix could not find file exception](https://github.com/dudinda/External-Merge-Sorting/commit/b152821a8ff13183b41e1a9ff63acc7c6af36125)
If different paths are specified in the configuration in fields `SortReadPath`, `SortWritePath`, `MergeStartPath`, `MergeStartTargetPath` the program crashes with error `Could not find file`. Fixed work with different folder paths for temporary files. Also fixed work with relative paths for folders for temporary files.


[Fix processing of line with long numeric parts](https://github.com/dudinda/External-Merge-Sorting/commit/0c95bb48ed8da85782883a9137cba48e72470238)
If the value in the numeric part of the string does not fit into the range of the int type, the program crashes with an error `Contains content with a broken format`. Added support for numbers of any size using standard classes with little effort and no performance penalty.


[Improve debugging usability by instantiating enumerations into arrays](https://github.com/dudinda/External-Merge-Sorting/commit/7d19fec475eee14a64736a009503488ca3d9cee3)
It is not possible to view the contents of an `IEnumerable` in debug mode. So for debugging purposes I converted the enumerations to arrays. No loss of performance was detected.